### PR TITLE
docs(margin): describes 'both' option for 'margin' attribute

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,5 +16,5 @@ auro-header is a custom element to make using headers with the Auro Design Syste
 | `color`   | `color`   | `String` |           | Allows user to pass in CSS custom property or direct hex value to change the color of the header |
 | `display` | `display` | `String` | "display" | Determines presentation of header. Options are `display`, `800`, `700`, `600`, `500`, `400`, `300`. |
 | `level`   | `level`   | `String` |           | Determines heading level for HTML element. Options are `1` - `6` |
-| `margin`  | `margin`  | `String` |           | Specify either top or bottom margin(s) to be altered |
+| `margin`  | `margin`  | `String` |           | Specify the margin(s) to be altered. Options are `top`, `bottom`, or `both`. |
 | `size`    | `size`    | `String` |           | Specify size of margin adjustment, either `none`, `xxxs`, `xxs`, `xs`, `sm`, `md`, `lg`, `xl`, `xxl` or `xxxl` |

--- a/src/auro-header.js
+++ b/src/auro-header.js
@@ -17,7 +17,7 @@ import styleCssFixed from './style-fixed-css.js';
  * @attr {String} level - Determines heading level for HTML element. Options are `1` - `6`
  * @attr {String} display - Determines presentation of header. Options are `display`, `800`, `700`, `600`, `500`, `400`, `300`.
  * @attr {String} color - Allows user to pass in CSS custom property or direct hex value to change the color of the header
- * @attr {String} margin - Specify either top or bottom margin(s) to be altered
+ * @attr {String} margin - Specify the margin(s) to be altered. Options are `top`, `bottom`, or `both`.
  * @attr {String} size - Specify size of margin adjustment, either `none`, `xxxs`, `xxs`, `xs`, `sm`, `md`, `lg`, `xl`, `xxl` or `xxxl`
  * @attr {String} type - **DEPRECATED** Option, `px`. Legacy option for converting REMs to PX. Use `fixed` feature.
  * @attr {Boolean} fixed - Uses px values instead of rem


### PR DESCRIPTION
# Alaska Airlines Pull Request

Describes 'both' option for 'margin' attribute in API docs.

**Fixes:** #45

## Type of change:

Please delete options that are not relevant.

- [X] Other (docs)

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**